### PR TITLE
chore: Format with air

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -15,3 +15,5 @@
 ^README\.Rmd$
 ^CODE_OF_CONDUCT\.md$
 
+^[.]?air[.]toml$
+^\.vscode$

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+    "recommendations": [
+        "Posit.air-vscode"
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,10 @@
+{
+  "[r]": {
+    "editor.formatOnSave": true,
+    "editor.defaultFormatter": "Posit.air-vscode"
+  },
+  "[quarto]": {
+    "editor.formatOnSave": true,
+    "editor.defaultFormatter": "quarto.quarto"
+  }
+}

--- a/R/collection.R
+++ b/R/collection.R
@@ -1,13 +1,15 @@
-fop_query_collection <- function(path,
-                                 collection_id,
-                                 filter = NULL,
-                                 limit = 10000,
-                                 offset = 0,
-                                 bbox = NULL,
-                                 properties = NULL,
-                                 transform = NULL,
-                                 sortby = NULL,
-                                 groupby = NULL) {
+fop_query_collection <- function(
+  path,
+  collection_id,
+  filter = NULL,
+  limit = 10000,
+  offset = 0,
+  bbox = NULL,
+  properties = NULL,
+  transform = NULL,
+  sortby = NULL,
+  groupby = NULL
+) {
   base_url <- api_url()
   user <- gh_user()
 
@@ -40,15 +42,17 @@ fop_query_collection <- function(path,
 #' collection_id <- "bcfishobs.fiss_fish_obsrvtn_events_sp"
 #' filter <- list(species_code = "CO", watershed_group_code = "CLAY")
 #' fop_query_collection_observation(collection_id, filter = filter)
-fop_query_collection_observation <- function(collection_id,
-                                             filter = NULL,
-                                             limit = 10000,
-                                             offset = 0,
-                                             bbox = NULL,
-                                             properties = NULL,
-                                             transform = NULL,
-                                             sortby = NULL,
-                                             groupby = NULL) {
+fop_query_collection_observation <- function(
+  collection_id,
+  filter = NULL,
+  limit = 10000,
+  offset = 0,
+  bbox = NULL,
+  properties = NULL,
+  transform = NULL,
+  sortby = NULL,
+  groupby = NULL
+) {
   path <- path_obs()
 
   fop_query_collection(
@@ -77,15 +81,17 @@ fop_query_collection_observation <- function(collection_id,
 #' collection_id <- "bcfishpass.barriers_falls"
 #' filter <- list(barrier_type = "FALLS")
 #' fop_query_collection_passage(collection_id, filter = filter)
-fop_query_collection_passage <- function(collection_id,
-                                         filter = NULL,
-                                         limit = 10000,
-                                         offset = 0,
-                                         bbox = NULL,
-                                         properties = NULL,
-                                         transform = NULL,
-                                         sortby = NULL,
-                                         groupby = NULL) {
+fop_query_collection_passage <- function(
+  collection_id,
+  filter = NULL,
+  limit = 10000,
+  offset = 0,
+  bbox = NULL,
+  properties = NULL,
+  transform = NULL,
+  sortby = NULL,
+  groupby = NULL
+) {
   path <- path_pass()
 
   fop_query_collection(

--- a/air.toml
+++ b/air.toml
@@ -1,0 +1,7 @@
+[format]
+line-width = 80
+indent-width = 2
+indent-style = "space"
+line-ending = "auto"
+persistent-line-breaks = true
+default-exclude = true

--- a/tests/testthat/test-collection.R
+++ b/tests/testthat/test-collection.R
@@ -41,15 +41,29 @@ test_that("collection observation filter works", {
   expect_true(all(x$watershed_group_code == "CLAY"))
 
   colnames <- c(
-    "agency_id", "agency_name", "blue_line_key", "distance_to_stream",
-    "downstream_route_measure", "fish_observation_point_id", "linear_feature_id",
-    "localcode_ltree", "match_type", "observation_date", "source", "source_ref",
-    "species_code", "species_id", "waterbody_key", "watershed_group_code",
-    "wscode_ltree", "geometry"
+    "agency_id",
+    "agency_name",
+    "blue_line_key",
+    "distance_to_stream",
+    "downstream_route_measure",
+    "fish_observation_point_id",
+    "linear_feature_id",
+    "localcode_ltree",
+    "match_type",
+    "observation_date",
+    "source",
+    "source_ref",
+    "species_code",
+    "species_id",
+    "waterbody_key",
+    "watershed_group_code",
+    "wscode_ltree",
+    "geometry"
   )
 
   expect_identical(
-    colnames(x), colnames
+    colnames(x),
+    colnames
   )
   testthat::skip_on_os("linux")
   expect_snapshot_data(x[setdiff(colnames, "geometry")], "co_clay")
@@ -102,7 +116,8 @@ test_that("collection informative error invalid bbox", {
 
 test_that("collection informative error invalid bbox", {
   collection_id <- "bcfishobs.fiss_fish_obsrvtn_events_sp"
-  expect_chk_error(fop_query_collection_observation(collection_id,
-                                                    filter = c(1)
+  expect_chk_error(fop_query_collection_observation(
+    collection_id,
+    filter = c(1)
   ))
 })

--- a/tests/testthat/test-collections.R
+++ b/tests/testthat/test-collections.R
@@ -1,21 +1,33 @@
 test_that("fop_collections_observation works", {
   collections <- fop_collections_observation()
   expect_s3_class(collections, "tbl_df")
-  expect_identical(names(collections), c("collection_id", "description", "extent", "links"))
+  expect_identical(
+    names(collections),
+    c("collection_id", "description", "extent", "links")
+  )
 })
 
 test_that("fop_collections_passage works", {
   collections <- fop_collections_passage()
   expect_s3_class(collections, "tbl_df")
-  expect_identical(names(collections), c("collection_id", "description", "extent", "links"))
+  expect_identical(
+    names(collections),
+    c("collection_id", "description", "extent", "links")
+  )
 })
 
 test_that("fop_collections_observation collection_id values haven't changed", {
   collections_observation <- fop_collections_observation()
-  expect_snapshot_data(collections_observation["collection_id"], "collections_observation")
+  expect_snapshot_data(
+    collections_observation["collection_id"],
+    "collections_observation"
+  )
 })
 
 test_that("fop_collections_passage collection_id values haven't changed", {
   collections_passage <- fop_collections_passage()
-  expect_snapshot_data(collections_passage["collection_id"], "collections_passage")
+  expect_snapshot_data(
+    collections_passage["collection_id"],
+    "collections_passage"
+  )
 })


### PR DESCRIPTION
Adds air formatting following the org standard (as in `chk`):

- `air.toml` with the standard `[format]` settings
- `.vscode/` settings recommending and enabling format-on-save with Posit air
- `.Rbuildignore` entries for `air.toml` and `.vscode`
- All R source formatted with `air format .` (air 0.9.0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)